### PR TITLE
Fix: Bug: ReasoningEffort type error during Google provider initialization

### DIFF
--- a/lib/providers/google/config.dart
+++ b/lib/providers/google/config.dart
@@ -127,7 +127,8 @@ class GoogleConfig {
       topK: config.topK,
       tools: config.tools,
       // Google-specific extensions
-      reasoningEffort: config.getExtension<ReasoningEffort>('reasoningEffort'),
+      reasoningEffort: ReasoningEffort.fromString(
+          config.getExtension<String>('reasoningEffort')),
       thinkingBudgetTokens: config.getExtension<int>('thinkingBudgetTokens'),
       includeThoughts: config.getExtension<bool>('includeThoughts'),
       enableImageGeneration: config.getExtension<bool>('enableImageGeneration'),


### PR DESCRIPTION
# Pull Request

## Description

<!-- Brief description of the changes -->

## Type of Change

- [X] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🤖 New provider

## Related Issues

https://github.com/Latias94/llm_dart/issues/4

## Changes Made

Just a small enum to string

## Checklist

Before marking this PR as ready for review, please ensure you have:

- [X] ✅ Run `dart analyze` and fixed all issues
- [X] 🧪 Run `dart test` and all tests pass
- [ ] 📝 Added tests for new features (if applicable)
- [ ] 📚 Updated documentation (if applicable)
- [X] 🔍 Tested with real API keys (if applicable)
