### PR TITLE
feat: add thinking support for Ollama reasoning models

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ A modular Dart library for AI provider interactions. This library provides a uni
 
 - **Multi-provider support**: OpenAI, Anthropic, Google, DeepSeek, Groq, Ollama, xAI, ElevenLabs
 - **OpenAI Responses API**: Stateful conversations with built-in tools (web search, file search, computer use)
-- **Thinking process access**: Model reasoning for Claude, DeepSeek, Gemini
+- **Thinking process access**: Model reasoning for Claude, DeepSeek, Gemini, Ollama
 - **Unified capabilities**: Chat, streaming, tools, audio, images, files, web search, embeddings
 - **MCP integration**: Model Context Protocol for external tool access
 - **Content moderation**: Built-in safety and content filtering
@@ -47,7 +47,7 @@ A modular Dart library for AI provider interactions. This library provides a uni
 | Google | ✅ | ✅ | ✅ | 🧠 | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | Gemini models with reasoning |
 | DeepSeek | ✅ | ✅ | ✅ | 🧠 | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | DeepSeek reasoning models |
 | Groq | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | Ultra-fast inference |
-| Ollama | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | Local models, privacy-focused |
+| Ollama | ✅ | ✅ | ✅ | 🧠 | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | Local models, privacy-focused |
 | xAI | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | Grok models with web search |
 | ElevenLabs | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | Advanced voice synthesis |
 
@@ -392,14 +392,25 @@ if (response.thinking != null) {
 }
 ```
 
-### Ollama
+### Ollama (with Thinking Process)
 
 ```dart
-final provider = ollama(
-  baseUrl: 'http://localhost:11434',
-  model: 'llama3.2',
-  // No API key needed for local Ollama
-);
+// Ollama with thinking enabled
+final provider = await ai()
+    .ollama()
+    .baseUrl('http://localhost:11434')
+    .model('gpt-oss:latest') // Reasoning model
+    .reasoning(true)         // Enable reasoning process
+    .build();
+
+final response = await provider.chat([
+  ChatMessage.user('Solve this math problem step by step: 15 * 23 + 7')
+]);
+
+// Access Ollama's thinking process
+if (response.thinking != null) {
+  print('Ollama\'s reasoning: ${response.thinking}');
+}
 ```
 
 ### xAI (with Web Search)

--- a/example/04_providers/ollama/README.md
+++ b/example/04_providers/ollama/README.md
@@ -7,6 +7,9 @@ Local AI model deployment for privacy and offline capabilities.
 ### [advanced_features.dart](advanced_features.dart)
 Local model deployment, performance optimization, and custom configurations.
 
+### [thinking_example.dart](thinking_example.dart)
+Reasoning and thinking capabilities with local models.
+
 ## Setup
 
 ```bash
@@ -21,6 +24,7 @@ ollama serve
 
 # Run Ollama example
 dart run advanced_features.dart
+dart run thinking_example.dart
 ```
 
 ## Unique Capabilities
@@ -34,6 +38,11 @@ dart run advanced_features.dart
 - **Hardware Optimization**: GPU acceleration and CPU tuning
 - **Custom Models**: Import and fine-tune your own models
 - **Resource Management**: Control memory and processing allocation
+
+### Reasoning Models
+- **Local Thinking**: Run reasoning models completely offline
+- **Privacy-First**: No thinking process sent to external servers
+- **Cost-Free Reasoning**: No API charges for complex reasoning tasks
 
 ## Usage Examples
 
@@ -66,6 +75,23 @@ final provider = await ai().ollama()
 final response = await provider.chat([
   ChatMessage.user('Analyze this sensitive document'),
 ]);
+```
+
+### Reasoning Models
+```dart
+// Local reasoning with thinking process
+final provider = await ai().ollama()
+    .baseUrl('http://localhost:11434')
+    .model('gpt-oss:latest') // Reasoning model
+    .reasoning(true)         // Enable reasoning process
+    .build();
+
+final response = await provider.chat([
+  ChatMessage.user('Solve this step by step: What is 15 * 23 + 7 * 11?'),
+]);
+
+print('Thinking: ${response.thinking}');
+print('Answer: ${response.text}');
 ```
 
 ## Next Steps

--- a/example/04_providers/ollama/thinking_example.dart
+++ b/example/04_providers/ollama/thinking_example.dart
@@ -1,0 +1,371 @@
+// ignore_for_file: avoid_print
+import 'dart:io';
+import 'package:llm_dart/llm_dart.dart';
+
+/// 🦙 Ollama Thinking - Local Reasoning with Open Models
+///
+/// This example demonstrates Ollama's thinking capabilities with reasoning models:
+/// - Local inference with thinking models
+/// - Step-by-step reasoning process
+/// - Streaming thinking observations
+/// - Various reasoning model comparisons
+///
+/// Prerequisites:
+/// 1. Install Ollama: https://ollama.ai/
+/// 2. Pull a reasoning model: ollama pull gpt-oss:latest
+/// 3. Start Ollama server: ollama serve
+void main() async {
+  print('🦙 Ollama Thinking - Local Reasoning with Open Models\n');
+
+  // Demonstrate various Ollama thinking capabilities
+  await demonstrateBasicThinking();
+  await demonstrateMathematicalReasoning();
+  await demonstrateStreamingThinking();
+  await demonstrateLogicalPuzzle();
+  await demonstrateModelComparison();
+
+  print('\n✅ Ollama thinking demonstrations completed!');
+}
+
+/// Demonstrate basic thinking process with Ollama
+Future<void> demonstrateBasicThinking() async {
+  print('🧠 Basic Thinking Process:\n');
+
+  try {
+    final provider = await ai()
+        .ollama()
+        .baseUrl('http://localhost:11434')
+        .model('gpt-oss:latest')
+        .reasoning(true)
+        .temperature(0.3)
+        .maxTokens(1000)
+        .build();
+
+    final response = await provider.chat([
+      ChatMessage.user('''
+I have 3 red balls, 2 blue balls, and 5 green balls in a bag.
+If I randomly pick 3 balls without replacement, what's the probability
+that I get exactly one ball of each color?
+''')
+    ]);
+
+    print('   Problem: Probability calculation with colored balls');
+    print('   Model: gpt-oss:latest (local reasoning model)');
+
+    // Show the thinking process if available
+    if (response.thinking != null && response.thinking!.isNotEmpty) {
+      print('\n   🧠 Ollama\'s Thinking Process:');
+      print('   ${'-' * 50}');
+      print('   ${response.thinking}');
+      print('   ${'-' * 50}');
+    }
+
+    print('\n   🎯 Final Answer:');
+    print('   ${response.text}');
+
+    if (response.usage != null) {
+      print('\n   📊 Usage: ${response.usage!.totalTokens} tokens');
+    }
+
+    print('   ✅ Basic thinking demonstration completed\n');
+  } catch (e) {
+    if (e.toString().contains('404') ||
+        e.toString().contains('model') ||
+        e.toString().contains('not found')) {
+      print(
+          '   ❌ Model not available. Try running: ollama pull gpt-oss:latest');
+      print('   📋 Alternative models: qwen2.5:latest, llama3.2:latest');
+    } else {
+      print('   ❌ Basic thinking failed: $e');
+    }
+    print('\n');
+  }
+}
+
+/// Demonstrate mathematical reasoning
+Future<void> demonstrateMathematicalReasoning() async {
+  print('🔢 Mathematical Reasoning:\n');
+
+  try {
+    final provider = await ai()
+        .ollama()
+        .baseUrl('http://localhost:11434')
+        .model('gpt-oss:latest')
+        .reasoning(true)
+        .temperature(0.1) // Lower for precise calculations
+        .maxTokens(1500)
+        .build();
+
+    final mathProblem = '''
+A company's revenue follows this pattern:
+- Month 1: \$10,000
+- Month 2: \$12,000
+- Month 3: \$14,400
+- Month 4: \$17,280
+
+What is the growth pattern, and what will be the revenue in Month 6?
+Show your work step by step.
+''';
+
+    final response = await provider.chat([ChatMessage.user(mathProblem)]);
+
+    print('   Problem: Revenue pattern analysis and prediction');
+
+    if (response.thinking != null && response.thinking!.isNotEmpty) {
+      print('\n   🧠 Ollama\'s Mathematical Process:');
+      print('   ${'-' * 60}');
+      // Show first part of thinking to avoid too much output
+      final thinking = response.thinking!;
+      if (thinking.length > 500) {
+        print('   ${thinking.substring(0, 500)}...');
+        print(
+            '   [Thinking process continues for ${thinking.length} total characters]');
+      } else {
+        print('   $thinking');
+      }
+      print('   ${'-' * 60}');
+    }
+
+    print('\n   🎯 Mathematical Analysis:');
+    print('   ${response.text}');
+
+    print('   ✅ Mathematical reasoning demonstration completed\n');
+  } catch (e) {
+    print('   ❌ Mathematical reasoning failed: $e\n');
+  }
+}
+
+/// Demonstrate streaming thinking
+Future<void> demonstrateStreamingThinking() async {
+  print('🌊 Streaming Thinking Process:\n');
+
+  try {
+    final provider = await ai()
+        .ollama()
+        .baseUrl('http://localhost:11434')
+        .model('gpt-oss:latest')
+        .reasoning(true)
+        .temperature(0.4)
+        .maxTokens(1200)
+        .build();
+
+    print('   Problem: Logic puzzle with real-time thinking');
+    print('   Watching Ollama think in real-time...\n');
+
+    var thinkingContent = StringBuffer();
+    var responseContent = StringBuffer();
+    var isThinking = true;
+
+    await for (final event in provider.chatStream([
+      ChatMessage.user('''
+Four people need to cross a bridge at night. They have one flashlight.
+The bridge can hold only two people at a time. They must walk together
+when crossing. Person A takes 1 minute, B takes 2 minutes, C takes 5 minutes,
+and D takes 10 minutes. When two people cross together, they walk at the
+slower person's pace. What's the minimum time to get everyone across?
+''')
+    ])) {
+      switch (event) {
+        case ThinkingDeltaEvent(delta: final delta):
+          thinkingContent.write(delta);
+          // Print thinking in gray color
+          stdout.write('\x1B[90m$delta\x1B[0m');
+          break;
+        case TextDeltaEvent(delta: final delta):
+          if (isThinking) {
+            print('\n\n   🎯 Ollama\'s Final Answer:');
+            print('   ${'-' * 40}');
+            isThinking = false;
+          }
+          responseContent.write(delta);
+          stdout.write(delta);
+          break;
+        case CompletionEvent(response: final response):
+          print('\n   ${'-' * 40}');
+          print('\n   ✅ Streaming thinking completed!');
+
+          if (response.usage != null) {
+            print('   📊 Usage: ${response.usage!.totalTokens} tokens');
+          }
+
+          print('   🧠 Thinking length: ${thinkingContent.length} characters');
+          print('   📝 Response length: ${responseContent.length} characters');
+          break;
+        case ErrorEvent(error: final error):
+          print('\n   ❌ Stream error: $error');
+          break;
+        case ToolCallDeltaEvent():
+          // Handle tool call events if needed
+          break;
+      }
+    }
+
+    print('   ✅ Streaming thinking demonstration completed\n');
+  } catch (e) {
+    print('   ❌ Streaming thinking failed: $e\n');
+  }
+}
+
+/// Demonstrate logical puzzle solving
+Future<void> demonstrateLogicalPuzzle() async {
+  print('🧩 Logical Puzzle Solving:\n');
+
+  try {
+    final provider = await ai()
+        .ollama()
+        .baseUrl('http://localhost:11434')
+        .model('gpt-oss:latest')
+        .reasoning(true)
+        .temperature(0.3)
+        .maxTokens(1500)
+        .build();
+
+    final logicPuzzle = '''
+You have 12 coins, one of which is fake (lighter than the others).
+You have a balance scale and can use it exactly 3 times.
+How do you identify the fake coin? Describe your strategy step by step.
+''';
+
+    final response = await provider.chat([ChatMessage.user(logicPuzzle)]);
+
+    print('   Puzzle: Classic 12-coin balance scale problem');
+
+    if (response.thinking != null && response.thinking!.isNotEmpty) {
+      print('\n   🧠 Ollama\'s Logic Process:');
+      print('   ${'-' * 50}');
+      // Show key parts of logical thinking
+      final thinking = response.thinking!;
+      final lines = thinking.split('\n');
+      var importantLines = <String>[];
+
+      for (final line in lines) {
+        final lowerLine = line.toLowerCase();
+        if (lowerLine.contains('step') ||
+            lowerLine.contains('weigh') ||
+            lowerLine.contains('divide') ||
+            lowerLine.contains('strategy')) {
+          importantLines.add(line.trim());
+        }
+      }
+
+      if (importantLines.isNotEmpty) {
+        for (final line in importantLines.take(5)) {
+          print('   $line');
+        }
+        if (importantLines.length > 5) {
+          print('   ... [${importantLines.length - 5} more logical steps]');
+        }
+      } else {
+        print('   ${thinking.substring(0, 400)}...');
+      }
+      print('   ${'-' * 50}');
+    }
+
+    print('\n   🎯 Logical Solution:');
+    print('   ${response.text}');
+
+    print('   ✅ Logical puzzle demonstration completed\n');
+  } catch (e) {
+    print('   ❌ Logical puzzle failed: $e\n');
+  }
+}
+
+/// Demonstrate model comparison
+Future<void> demonstrateModelComparison() async {
+  print('📊 Model Comparison:\n');
+
+  final testProblem = '''
+If you flip a fair coin 10 times and get 8 heads, what's the probability
+of getting heads on the 11th flip? Explain your reasoning.
+''';
+
+  final models = ['gpt-oss:latest', 'qwen2.5:latest', 'llama3.2:latest'];
+
+  for (final model in models) {
+    print('   Testing model: $model');
+
+    try {
+      final provider = await ai()
+          .ollama()
+          .baseUrl('http://localhost:11434')
+          .model(model)
+          .reasoning(true)
+          .temperature(0.2)
+          .maxTokens(800)
+          .build();
+
+      final response = await provider.chat([ChatMessage.user(testProblem)]);
+
+      if (response.thinking != null && response.thinking!.isNotEmpty) {
+        print('   ✅ Thinking capability: Available');
+        print('   🧠 Thinking length: ${response.thinking!.length} characters');
+      } else {
+        print('   ⚠️  Thinking capability: Not available');
+      }
+
+      print('   📝 Response quality: ${response.text?.length ?? 0} characters');
+
+      if (response.usage != null) {
+        print('   📊 Token usage: ${response.usage!.totalTokens}');
+      }
+
+      print('   ${'-' * 30}');
+    } catch (e) {
+      if (e.toString().contains('404') || e.toString().contains('not found')) {
+        print('   ❌ Model not available (not pulled)');
+      } else {
+        print('   ❌ Model test failed: $e');
+      }
+      print('   ${'-' * 30}');
+    }
+  }
+
+  print('   💡 Model Recommendations:');
+  print('      • gpt-oss:latest: Best for reasoning tasks');
+  print('      • qwen2.5:latest: Good balance of speed and quality');
+  print('      • llama3.2:latest: Lightweight option');
+
+  print('   ✅ Model comparison demonstration completed\n');
+}
+
+/// 🎯 Key Ollama Thinking Concepts Summary:
+///
+/// Local Reasoning Benefits:
+/// - Complete privacy and data control
+/// - No API costs or rate limits
+/// - Offline capability
+/// - Custom model fine-tuning possible
+///
+/// Thinking Process Features:
+/// - Step-by-step reasoning observation
+/// - Mathematical calculation verification
+/// - Logical puzzle breakdown
+/// - Real-time thinking via streaming
+///
+/// Best Practices:
+/// - Use lower temperature (0.1-0.3) for analytical tasks
+/// - Allow sufficient token budget for thinking
+/// - Test multiple models for best results
+/// - Stream thinking for real-time insight
+///
+/// Model Selection:
+/// - gpt-oss: Specialized reasoning model
+/// - qwen2.5: Good general-purpose option
+/// - llama3.2: Lightweight alternative
+///
+/// Configuration Tips:
+/// - Ensure Ollama server is running
+/// - Pre-pull models before use
+/// - Monitor system resources for large models
+/// - Use reasoning=true flag for thinking
+///
+/// Limitations:
+/// - Requires local computational resources
+/// - Model availability depends on local pulls
+/// - Thinking quality varies by model
+/// - Slower than cloud-based solutions
+///
+/// Next Steps:
+/// - ../anthropic/extended_thinking.dart: Compare with cloud reasoning
+/// - ../../03_advanced_features/reasoning_models.dart: Cross-provider comparison
+/// - vision_capabilities.dart: Visual reasoning with local models

--- a/lib/builder/llm_builder.dart
+++ b/lib/builder/llm_builder.dart
@@ -254,7 +254,7 @@ class LLMBuilder {
     return this;
   }
 
-  /// Enables reasoning/thinking for supported providers (Anthropic, OpenAI o1)
+  /// Enables reasoning/thinking for supported providers (Anthropic, OpenAI o1, Ollama)
   LLMBuilder reasoning(bool enable) {
     _config = _config.withExtension('reasoning', enable);
     return this;

--- a/lib/core/capability.dart
+++ b/lib/core/capability.dart
@@ -365,8 +365,9 @@ class CompletionRequest {
 class CompletionResponse {
   final String text;
   final UsageInfo? usage;
+  final String? thinking;
 
-  const CompletionResponse({required this.text, this.usage});
+  const CompletionResponse({required this.text, this.usage, this.thinking});
 
   @override
   String toString() => text;

--- a/lib/providers/factories/ollama_factory.dart
+++ b/lib/providers/factories/ollama_factory.dart
@@ -40,20 +40,6 @@ class OllamaProviderFactory extends LocalProviderFactory<ChatCapability> {
 
   /// Transform unified config to Ollama-specific config
   OllamaConfig _transformConfig(LLMConfig config) {
-    return OllamaConfig(
-      baseUrl: config.baseUrl,
-      apiKey: config.apiKey, // Optional for Ollama
-      model: config.model,
-      maxTokens: config.maxTokens,
-      temperature: config.temperature,
-      systemPrompt: config.systemPrompt,
-      timeout: config.timeout,
-      topP: config.topP,
-      topK: config.topK,
-      tools: config.tools,
-      // Ollama-specific extensions using safe access
-      jsonSchema: getExtension(config, 'jsonSchema'),
-      originalConfig: config,
-    );
+    return OllamaConfig.fromLLMConfig(config);
   }
 }

--- a/lib/providers/ollama/builder.dart
+++ b/lib/providers/ollama/builder.dart
@@ -180,6 +180,18 @@ class OllamaBuilder {
         .numa(true); // Enable NUMA optimization
   }
 
+  /// Enables thinking for reasoning models
+  ///
+  /// When enabled, the model will think before responding.
+  /// Only works with models that support reasoning/thinking.
+  ///
+  /// - true: Enable reasoning mode
+  /// - false: Disable reasoning mode (default)
+  OllamaBuilder reasoning(bool enabled) {
+    _baseBuilder.extension('reasoning', enabled);
+    return this;
+  }
+
   /// Configure for CPU-only inference
   ///
   /// Optimized for systems without GPU or when GPU usage

--- a/lib/providers/ollama/completion.dart
+++ b/lib/providers/ollama/completion.dart
@@ -65,6 +65,11 @@ class OllamaCompletion implements CompletionCapability {
     // Add keep_alive parameter for model memory management
     body['keep_alive'] = config.keepAlive ?? '5m'; // Default 5 minutes
 
+    // Add thinking parameter, if not passed, it will depend on the model's default behavior
+    if (config.reasoning != null) {
+      body['think'] = config.reasoning;
+    }
+
     return body;
   }
 
@@ -77,6 +82,8 @@ class OllamaCompletion implements CompletionCapability {
       throw const ProviderError('No answer returned by Ollama');
     }
 
-    return CompletionResponse(text: text);
+    final thinking = responseData['thinking'] as String?;
+
+    return CompletionResponse(text: text, thinking: thinking);
   }
 }

--- a/lib/providers/ollama/config.dart
+++ b/lib/providers/ollama/config.dart
@@ -28,6 +28,7 @@ class OllamaConfig {
   final int? numBatch; // Batch size
   final String? keepAlive; // How long to keep model in memory
   final bool? raw; // Raw mode (no templating)
+  final bool? reasoning; // Enable thinking for reasoning models
 
   /// Reference to original LLMConfig for accessing extensions
   final LLMConfig? _originalConfig;
@@ -52,6 +53,7 @@ class OllamaConfig {
     this.numBatch,
     this.keepAlive,
     this.raw,
+    this.reasoning,
     LLMConfig? originalConfig,
   }) : _originalConfig = originalConfig;
 
@@ -78,6 +80,7 @@ class OllamaConfig {
       numBatch: config.getExtension<int>('numBatch'),
       keepAlive: config.getExtension<String>('keepAlive'),
       raw: config.getExtension<bool>('raw'),
+      reasoning: config.getExtension<bool>('reasoning'),
       originalConfig: config,
     );
   }
@@ -93,7 +96,9 @@ class OllamaConfig {
     // Some Ollama models support reasoning, especially newer ones
     return model.contains('reasoning') ||
         model.contains('think') ||
-        model.contains('qwen2.5');
+        model.contains('qwen2.5') ||
+        model.contains('gpt-oss') ||
+        model.contains('deepseek-r1');
   }
 
   /// Check if this model supports vision
@@ -172,6 +177,7 @@ class OllamaConfig {
     int? numBatch,
     String? keepAlive,
     bool? raw,
+    bool? reasoning,
   }) =>
       OllamaConfig(
         baseUrl: baseUrl ?? this.baseUrl,
@@ -192,5 +198,6 @@ class OllamaConfig {
         numBatch: numBatch ?? this.numBatch,
         keepAlive: keepAlive ?? this.keepAlive,
         raw: raw ?? this.raw,
+        reasoning: reasoning ?? this.reasoning,
       );
 }

--- a/lib/providers/ollama/ollama.dart
+++ b/lib/providers/ollama/ollama.dart
@@ -69,6 +69,7 @@ OllamaProvider createOllamaProvider({
   int? numBatch,
   String? keepAlive,
   bool? raw,
+  bool? reasoning,
 }) {
   final config = OllamaConfig(
     baseUrl: baseUrl ?? 'http://localhost:11434',
@@ -89,6 +90,7 @@ OllamaProvider createOllamaProvider({
     numBatch: numBatch,
     keepAlive: keepAlive,
     raw: raw,
+    reasoning: reasoning,
   );
 
   return OllamaProvider(config);
@@ -168,5 +170,20 @@ OllamaProvider createOllamaCompletionProvider({
     model: model,
     temperature: temperature,
     maxTokens: maxTokens,
+  );
+}
+
+/// Create an Ollama provider for reasoning tasks
+OllamaProvider createOllamaReasoningProvider({
+  String baseUrl = 'http://localhost:11434',
+  String model = 'gpt-oss:latest',
+  String? systemPrompt,
+  bool reasoning = true,
+}) {
+  return createOllamaProvider(
+    baseUrl: baseUrl,
+    model: model,
+    systemPrompt: systemPrompt,
+    reasoning: reasoning,
   );
 }

--- a/test/providers/ollama/ollama_thinking_test.dart
+++ b/test/providers/ollama/ollama_thinking_test.dart
@@ -1,0 +1,214 @@
+import 'package:test/test.dart';
+import 'package:llm_dart/llm_dart.dart';
+
+void main() {
+  group('OllamaThinking', () {
+    test('OllamaConfig should support thinking configuration', () {
+      final config = OllamaConfig(
+        model: 'gpt-oss:latest',
+        reasoning: true,
+      );
+
+      expect(config.reasoning, isTrue);
+      expect(config.supportsReasoning, isTrue);
+    });
+
+    test('OllamaConfig copyWith should preserve thinking setting', () {
+      final originalConfig = OllamaConfig(
+        model: 'gpt-oss:latest',
+        reasoning: true,
+      );
+
+      final copiedConfig = originalConfig.copyWith(temperature: 0.8);
+
+      expect(copiedConfig.reasoning, isTrue);
+      expect(copiedConfig.temperature, equals(0.8));
+    });
+
+    test('OllamaConfig should recognize reasoning models', () {
+      final configs = [
+        OllamaConfig(model: 'gpt-oss:latest'),
+        OllamaConfig(model: 'deepseek-r1:latest'),
+        OllamaConfig(model: 'qwen2.5-reasoning'),
+        OllamaConfig(model: 'thinking-model'),
+      ];
+
+      for (final config in configs) {
+        expect(config.supportsReasoning, isTrue,
+            reason: 'Model ${config.model} should support reasoning');
+      }
+    });
+
+    test('OllamaConfig should not recognize non-reasoning models', () {
+      final configs = [
+        OllamaConfig(model: 'llama3.2'),
+        OllamaConfig(model: 'mistral'),
+        OllamaConfig(model: 'phi3'),
+      ];
+
+      for (final config in configs) {
+        expect(config.supportsReasoning, isFalse,
+            reason: 'Model ${config.model} should not support reasoning');
+      }
+    });
+
+    test(
+        'createOllamaReasoningProvider should create provider with thinking enabled',
+        () {
+      final provider = createOllamaReasoningProvider(
+        baseUrl: 'http://localhost:11434',
+        model: 'gpt-oss:latest',
+      );
+
+      expect(provider, isA<OllamaProvider>());
+    });
+
+    test('createOllamaProvider should accept thinking parameter', () {
+      final provider = createOllamaProvider(
+        baseUrl: 'http://localhost:11434',
+        model: 'gpt-oss:latest',
+        reasoning: true,
+      );
+
+      expect(provider, isA<OllamaProvider>());
+    });
+
+    test('OllamaConfig.fromLLMConfig should handle reasoning extension', () {
+      final llmConfig = LLMConfig(
+        apiKey: 'test',
+        baseUrl: 'http://localhost:11434',
+        model: 'gpt-oss:latest',
+        extensions: {'reasoning': true},
+      );
+
+      final ollamaConfig = OllamaConfig.fromLLMConfig(llmConfig);
+
+      expect(ollamaConfig.reasoning, isTrue);
+    });
+
+    test('OllamaConfig default thinking should be null', () {
+      final config = OllamaConfig(
+        model: 'test-model',
+      );
+
+      expect(config.reasoning, isNull);
+    });
+
+    test('Builder reasoning method should work end-to-end', () async {
+      final provider = await ai()
+          .ollama()
+          .baseUrl('http://localhost:11434')
+          .model('gpt-oss:latest')
+          .reasoning(true)
+          .build();
+
+      expect(provider, isA<OllamaProvider>());
+
+      final ollamaProvider = provider as OllamaProvider;
+      final config = ollamaProvider.config;
+      expect(config.reasoning, isTrue);
+    });
+
+    test('OllamaBuilder reasoning method should work end-to-end', () async {
+      final provider = await ai()
+          .ollama((builder) => builder.reasoning(true).keepAlive('5m'))
+          .baseUrl('http://localhost:11434')
+          .model('gpt-oss:latest')
+          .build();
+
+      expect(provider, isA<OllamaProvider>());
+
+      final ollamaProvider = provider as OllamaProvider;
+      final config = ollamaProvider.config;
+      expect(config.reasoning, isTrue);
+    });
+
+    test('OllamaChatResponse should handle thinking content in message', () {
+      final mockResponse = {
+        'message': {
+          'role': 'assistant',
+          'content': 'The answer is 42.',
+          'thinking': 'Let me think about this step by step...',
+        },
+        'done': true,
+      };
+
+      final response = OllamaChatResponse(mockResponse);
+
+      expect(
+          response.thinking, equals('Let me think about this step by step...'));
+      expect(response.text, equals('The answer is 42.'));
+    });
+
+    test('OllamaChatResponse should handle thinking content in root', () {
+      final mockResponse = {
+        'thinking': 'This is my thinking process...',
+        'response': 'The final answer.',
+        'done': true,
+      };
+
+      final response = OllamaChatResponse(mockResponse);
+
+      expect(response.thinking, equals('This is my thinking process...'));
+    });
+
+    test('OllamaChatResponse should return null when no thinking content', () {
+      final mockResponse = {
+        'message': {
+          'role': 'assistant',
+          'content': 'Just a regular response.',
+        },
+        'done': true,
+      };
+
+      final response = OllamaChatResponse(mockResponse);
+
+      expect(response.thinking, isNull);
+      expect(response.text, equals('Just a regular response.'));
+    });
+
+    test('OllamaChatResponse toString should include thinking content', () {
+      final mockResponse = {
+        'message': {
+          'role': 'assistant',
+          'content': 'The answer is 42.',
+          'thinking': 'Let me calculate...',
+        },
+        'done': true,
+      };
+
+      final response = OllamaChatResponse(mockResponse);
+      final stringOutput = response.toString();
+
+      expect(stringOutput, contains('Thinking: Let me calculate...'));
+      expect(stringOutput, contains('The answer is 42.'));
+    });
+
+    test('OllamaChatResponse toString should work without thinking', () {
+      final mockResponse = {
+        'message': {
+          'role': 'assistant',
+          'content': 'Just a response.',
+        },
+        'done': true,
+      };
+
+      final response = OllamaChatResponse(mockResponse);
+      final stringOutput = response.toString();
+
+      expect(stringOutput, equals('Just a response.'));
+      expect(stringOutput, isNot(contains('Thinking:')));
+    });
+
+    test('OllamaChatResponse toString should handle empty response', () {
+      final mockResponse = <String, dynamic>{
+        'done': true,
+      };
+
+      final response = OllamaChatResponse(mockResponse);
+      final stringOutput = response.toString();
+
+      expect(stringOutput, equals(''));
+    });
+  });
+}


### PR DESCRIPTION
# Pull Request

## Description

This PR implements thinking capabilities for Ollama reasoning models, allowing users to access the step-by-step reasoning process of models like `gpt-oss`, `deepseek-r1`, and `qwen2.5`.

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation
- [ ] 🤖 New provider

## Related Issues

No related issues

## Changes Made

- Extended `CompletionResponse` with optional `thinking` field to expose reasoning traces
- Added `think` parameter to `OllamaConfig` (also supports legacy `reasoning` extension)
- Enhanced model detection for reasoning-capable models (`gpt-oss`, `deepseek-r1`, `qwen2.5`)
- Implemented thinking support for both streaming and non-streaming completions
- Added comprehensive example (`thinking_example.dart`) with various reasoning scenarios
- Created test suite for thinking functionality
- Updated documentation with usage examples

### Usage Example

```dart
// Enable thinking for reasoning models
final provider = await ai().ollama()
    .baseUrl('http://localhost:11434')
    .model('gpt-oss:latest')
    .reasoning(true)  // Enable thinking process
    .build();

final response = await provider.chat([
  ChatMessage.user('Solve step by step: What is 15% of 240?'),
]);

print('Answer: ${response.text}');
print('Thinking: ${response.thinking}');  // Step-by-step reasoning
```

## Checklist

Before marking this PR as ready for review, please ensure you have:

- [x] ✅ Run `dart analyze` and fixed all issues
- [x] 🧪 Run `dart test` and all tests pass
- [x] 📝 Added tests for new features (if applicable)
- [x] 📚 Updated documentation (if applicable)
- [x] 🔍 Tested with real API keys (if applicable)
